### PR TITLE
feat(core): preserve artifact content from adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- Add `content: Option<String>` to `ArtifactMetadata` to preserve full artifact
+  contents returned by adapters when available. Update parser, adapters, and
+  CLI mapping to preferentially use `content` (falling back to `summary`).
+  Add parser unit tests.
+
 # Changelog
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
   CLI mapping to preferentially use `content` (falling back to `summary`).
   Add parser unit tests.
 
+- Guidance: adapters should populate `content` with the full artifact body
+  (when available) instead of only a short `summary` to enable deterministic
+  patch generation and preview. The CLI will prefer `content` and fall back to
+  `summary` when `content` is None.
+
 # Changelog
 
 ## Unreleased

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use serde_json::json;
 
 use cprcodr_core::adapters::MockAdapter;
-use cprcodr_core::adapters::{LMStudioAdapter, OllamaAdapter, LLMAdapter};
+use cprcodr_core::adapters::{LLMAdapter, LMStudioAdapter, OllamaAdapter};
 use cprcodr_core::session::Session;
 use cprcodr_core::Backend;
 use std::fs;
@@ -117,16 +117,16 @@ fn main() {
         }
         Some(Commands::Gen {
             prompt,
-                backend,
-                adapter,
-                url,
-                adapter_url,
-                adapter_api_key,
-                model,
-                timeout,
-                output,
-                dry_run,
-            }) => {
+            backend,
+            adapter,
+            url,
+            adapter_url,
+            adapter_api_key,
+            model,
+            timeout,
+            output,
+            dry_run,
+        }) => {
             let options = json!({
                 "model": model.clone().unwrap_or_default(),
                 "timeout": timeout.unwrap_or(0),
@@ -142,7 +142,13 @@ fn main() {
                         let a = cprcodr_core::adapters::LLMMockAdapter::new("mock:");
                         // run tokio runtime to call async adapter and map to artifacts
                         let rt = tokio::runtime::Runtime::new().unwrap();
-                        let resp = rt.block_on(async { a.call(cprcodr_core::adapters::trait_adapter::LLMRequest { prompt: prompt.clone(), max_tokens: None }).await });
+                        let resp = rt.block_on(async {
+                            a.call(cprcodr_core::adapters::trait_adapter::LLMRequest {
+                                prompt: prompt.clone(),
+                                max_tokens: None,
+                            })
+                            .await
+                        });
                         match resp {
                             Ok(arts) => {
                                 let vals: Vec<serde_json::Value> = arts.into_iter().map(|m| serde_json::json!({"path": m.path, "summary": m.summary, "content": m.content.unwrap_or(m.summary)})).collect();
@@ -153,9 +159,18 @@ fn main() {
                     }
                     "ollama" => {
                         let url = adapter_url.clone().unwrap_or_else(|| url.clone());
-                        let a = cprcodr_core::adapters::OllamaAdapter::new(url, adapter_api_key.clone());
+                        let a = cprcodr_core::adapters::OllamaAdapter::new(
+                            url,
+                            adapter_api_key.clone(),
+                        );
                         let rt = tokio::runtime::Runtime::new().unwrap();
-                        let resp = rt.block_on(async { a.call(cprcodr_core::adapters::trait_adapter::LLMRequest { prompt: prompt.clone(), max_tokens: None }).await });
+                        let resp = rt.block_on(async {
+                            a.call(cprcodr_core::adapters::trait_adapter::LLMRequest {
+                                prompt: prompt.clone(),
+                                max_tokens: None,
+                            })
+                            .await
+                        });
                         match resp {
                             Ok(arts) => {
                                 let vals: Vec<serde_json::Value> = arts.into_iter().map(|m| serde_json::json!({"path": m.path, "summary": m.summary, "content": m.content.unwrap_or(m.summary)})).collect();
@@ -166,9 +181,18 @@ fn main() {
                     }
                     "lmstudio" => {
                         let url = adapter_url.clone().unwrap_or_else(|| url.clone());
-                        let a = cprcodr_core::adapters::LMStudioAdapter::new(url, adapter_api_key.clone());
+                        let a = cprcodr_core::adapters::LMStudioAdapter::new(
+                            url,
+                            adapter_api_key.clone(),
+                        );
                         let rt = tokio::runtime::Runtime::new().unwrap();
-                        let resp = rt.block_on(async { a.call(cprcodr_core::adapters::trait_adapter::LLMRequest { prompt: prompt.clone(), max_tokens: None }).await });
+                        let resp = rt.block_on(async {
+                            a.call(cprcodr_core::adapters::trait_adapter::LLMRequest {
+                                prompt: prompt.clone(),
+                                max_tokens: None,
+                            })
+                            .await
+                        });
                         match resp {
                             Ok(arts) => {
                                 let vals: Vec<serde_json::Value> = arts.into_iter().map(|m| serde_json::json!({"path": m.path, "summary": m.summary, "content": m.content.unwrap_or(m.summary)})).collect();

--- a/crates/cli/tests/gen_mock.rs
+++ b/crates/cli/tests/gen_mock.rs
@@ -21,5 +21,5 @@ fn gen_with_mock_backend_saves_artifacts() {
         .filter_map(|e| e.ok())
         .collect();
     // expect at least one JSON file with -artifacts.json or session file
-    assert!(entries.len() >= 1, "expected files in output dir");
+    assert!(!entries.is_empty(), "expected files in output dir");
 }

--- a/crates/core/src/adapters/lmstudio.rs
+++ b/crates/core/src/adapters/lmstudio.rs
@@ -1,9 +1,9 @@
+use super::trait_adapter::{parse_artifacts_from_text, LLMAdapter, LLMRequest};
 use crate::backend::{Artifacts, Backend, BackendError};
-use reqwest::blocking::Client;
-use serde_json::{json, Value};
-use super::trait_adapter::{LLMAdapter, LLMRequest, parse_artifacts_from_text};
 use async_trait::async_trait;
+use reqwest::blocking::Client;
 use reqwest::Client as AsyncClient;
+use serde_json::{json, Value};
 
 pub struct LMStudioAdapter {
     pub url: String,
@@ -12,41 +12,59 @@ pub struct LMStudioAdapter {
 
 impl LMStudioAdapter {
     pub fn new(url: impl Into<String>, api_key: Option<String>) -> Self {
-        LMStudioAdapter { url: url.into(), api_key }
+        LMStudioAdapter {
+            url: url.into(),
+            api_key,
+        }
     }
 }
 
 impl Backend for LMStudioAdapter {
     fn generate(&self, prompt: &str, options: Value) -> Result<Artifacts, BackendError> {
-        let client = Client::builder().build().map_err(|e| BackendError::Network(e.to_string()))?;
-        let mut req = client.post(format!("{}/api/generate", self.url)).json(&json!({
-            "input": prompt,
-            "params": options,
-        }));
+        let client = Client::builder()
+            .build()
+            .map_err(|e| BackendError::Network(e.to_string()))?;
+        let mut req = client
+            .post(format!("{}/api/generate", self.url))
+            .json(&json!({
+                "input": prompt,
+                "params": options,
+            }));
         if let Some(k) = &self.api_key {
             req = req.header("X-API-Key", k);
         }
-        let resp = req.send().map_err(|e| BackendError::Network(e.to_string()))?;
+        let resp = req
+            .send()
+            .map_err(|e| BackendError::Network(e.to_string()))?;
         if !resp.status().is_success() {
             return Err(BackendError::Protocol(format!("status {}", resp.status())));
         }
-        let v: Value = resp.json().map_err(|e| BackendError::Protocol(e.to_string()))?;
+        let v: Value = resp
+            .json()
+            .map_err(|e| BackendError::Protocol(e.to_string()))?;
         // LMStudio has `results` top-level by convention in this adapter (map to artifacts)
-        Ok(Artifacts { artifacts: v["results"].as_array().cloned().unwrap_or_default() })
+        Ok(Artifacts {
+            artifacts: v["results"].as_array().cloned().unwrap_or_default(),
+        })
     }
 }
 
 #[async_trait]
 impl LLMAdapter for LMStudioAdapter {
-    async fn call(&self, req: LLMRequest) -> Result<Vec<crate::artifact::ArtifactMetadata>, String> {
+    async fn call(
+        &self,
+        req: LLMRequest,
+    ) -> Result<Vec<crate::artifact::ArtifactMetadata>, String> {
         let client = AsyncClient::builder()
             .build()
             .map_err(|e| format!("client build error: {}", e))?;
 
-        let mut builder = client.post(format!("{}/api/generate", self.url)).json(&json!({
-            "input": req.prompt,
-            "params": { "max_tokens": req.max_tokens },
-        }));
+        let mut builder = client
+            .post(format!("{}/api/generate", self.url))
+            .json(&json!({
+                "input": req.prompt,
+                "params": { "max_tokens": req.max_tokens },
+            }));
         if let Some(k) = &self.api_key {
             builder = builder.header("X-API-Key", k);
         }

--- a/crates/core/src/adapters/mock.rs
+++ b/crates/core/src/adapters/mock.rs
@@ -56,6 +56,12 @@ impl LLMAdapter for LLMMockAdapter {
     }
 }
 
+impl Default for MockAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MockAdapter {
     // new() will check MOCK_ADAPTER_RESPONSE env var. If set and points to a file
     // containing a JSON array or object, it will use that as the deterministic response.
@@ -123,7 +129,7 @@ impl Backend for MockAdapter {
                 let arr = seed_val.as_array().unwrap();
                 // if the first element looks like an artifact (has 'path' or 'summary'),
                 // treat the whole array as the artifacts response
-                if let Some(first) = arr.get(0) {
+                if let Some(first) = arr.first() {
                     if first.is_object()
                         && (first.get("path").is_some()
                             || first.get("summary").is_some()

--- a/crates/core/src/adapters/ollama.rs
+++ b/crates/core/src/adapters/ollama.rs
@@ -1,9 +1,9 @@
+use super::trait_adapter::{parse_artifacts_from_text, LLMAdapter, LLMRequest};
 use crate::backend::{Artifacts, Backend, BackendError};
-use reqwest::blocking::Client;
-use serde_json::{json, Value};
-use super::trait_adapter::{LLMAdapter, LLMRequest, parse_artifacts_from_text};
 use async_trait::async_trait;
+use reqwest::blocking::Client;
 use reqwest::Client as AsyncClient;
+use serde_json::{json, Value};
 
 pub struct OllamaAdapter {
     pub url: String,
@@ -12,13 +12,18 @@ pub struct OllamaAdapter {
 
 impl OllamaAdapter {
     pub fn new(url: impl Into<String>, api_key: Option<String>) -> Self {
-        OllamaAdapter { url: url.into(), api_key }
+        OllamaAdapter {
+            url: url.into(),
+            api_key,
+        }
     }
 }
 
 impl Backend for OllamaAdapter {
     fn generate(&self, prompt: &str, options: Value) -> Result<Artifacts, BackendError> {
-        let client = Client::builder().build().map_err(|e| BackendError::Network(e.to_string()))?;
+        let client = Client::builder()
+            .build()
+            .map_err(|e| BackendError::Network(e.to_string()))?;
         let mut req = client.post(format!("{}/generate", self.url)).json(&json!({
             "prompt": prompt,
             "options": options,
@@ -26,18 +31,27 @@ impl Backend for OllamaAdapter {
         if let Some(k) = &self.api_key {
             req = req.header("Authorization", format!("Bearer {}", k));
         }
-        let resp = req.send().map_err(|e| BackendError::Network(e.to_string()))?;
+        let resp = req
+            .send()
+            .map_err(|e| BackendError::Network(e.to_string()))?;
         if !resp.status().is_success() {
             return Err(BackendError::Protocol(format!("status {}", resp.status())));
         }
-        let v: Value = resp.json().map_err(|e| BackendError::Protocol(e.to_string()))?;
-        Ok(Artifacts { artifacts: v["artifacts"].as_array().cloned().unwrap_or_default() })
+        let v: Value = resp
+            .json()
+            .map_err(|e| BackendError::Protocol(e.to_string()))?;
+        Ok(Artifacts {
+            artifacts: v["artifacts"].as_array().cloned().unwrap_or_default(),
+        })
     }
 }
 
 #[async_trait]
 impl LLMAdapter for OllamaAdapter {
-    async fn call(&self, req: LLMRequest) -> Result<Vec<crate::artifact::ArtifactMetadata>, String> {
+    async fn call(
+        &self,
+        req: LLMRequest,
+    ) -> Result<Vec<crate::artifact::ArtifactMetadata>, String> {
         // Basic async implementation: POST to {url}/generate with prompt and options.
         // This is intentionally minimal: callers should extend parsing per their API.
         let client = AsyncClient::builder()

--- a/crates/core/src/adapters/trait_adapter.rs
+++ b/crates/core/src/adapters/trait_adapter.rs
@@ -30,20 +30,47 @@ pub fn parse_artifacts_from_text(text: &str) -> Vec<ArtifactMetadata> {
             let mut out = Vec::new();
             for (i, it) in arr.iter().enumerate() {
                 if let Some(obj) = it.as_object() {
-                    let path = obj.get("path").and_then(|v| v.as_str()).map(|s| s.to_string()).unwrap_or_else(|| format!("generated/artifact-{}.txt", i + 1));
-                    let content_opt = obj.get("content").and_then(|v| v.as_str()).map(|s| s.to_string());
-                    let summary = content_opt.as_deref().map(summarize).unwrap_or_else(|| obj.get("summary").and_then(|v| v.as_str()).unwrap_or("").to_string());
+                    let path = obj
+                        .get("path")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!("generated/artifact-{}.txt", i + 1));
+                    let content_opt = obj
+                        .get("content")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let summary = content_opt.as_deref().map(summarize).unwrap_or_else(|| {
+                        obj.get("summary")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string()
+                    });
                     if let Some(c) = content_opt.clone() {
-                        out.push(ArtifactMetadata { path, summary: summarize(&c), checksum: None, content: Some(c) });
+                        out.push(ArtifactMetadata {
+                            path,
+                            summary: summarize(&c),
+                            checksum: None,
+                            content: Some(c),
+                        });
                         continue;
                     }
                     if !summary.is_empty() {
-                        out.push(ArtifactMetadata { path, summary, checksum: None, content: None });
+                        out.push(ArtifactMetadata {
+                            path,
+                            summary,
+                            checksum: None,
+                            content: None,
+                        });
                         continue;
                     }
                 }
                 // fallback for non-object array items
-                out.push(ArtifactMetadata { path: format!("generated/artifact-{}.json", i + 1), summary: it.to_string().chars().take(120).collect(), checksum: None, content: Some(it.to_string()) });
+                out.push(ArtifactMetadata {
+                    path: format!("generated/artifact-{}.json", i + 1),
+                    summary: it.to_string().chars().take(120).collect(),
+                    checksum: None,
+                    content: Some(it.to_string()),
+                });
             }
             if !out.is_empty() {
                 return out;
@@ -51,17 +78,40 @@ pub fn parse_artifacts_from_text(text: &str) -> Vec<ArtifactMetadata> {
         } else if val.is_object() {
             if let Some(obj) = val.as_object() {
                 if let Some(content) = obj.get("content").and_then(|v| v.as_str()) {
-                    let path = obj.get("path").and_then(|v| v.as_str()).map(|s| s.to_string()).unwrap_or_else(|| "generated/artifact-1.txt".to_string());
-                    return vec![ArtifactMetadata { path, summary: summarize(content), checksum: None, content: Some(content.to_string()) }];
+                    let path = obj
+                        .get("path")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| "generated/artifact-1.txt".to_string());
+                    return vec![ArtifactMetadata {
+                        path,
+                        summary: summarize(content),
+                        checksum: None,
+                        content: Some(content.to_string()),
+                    }];
                 }
                 if let Some(summary) = obj.get("summary").and_then(|v| v.as_str()) {
-                    let path = obj.get("path").and_then(|v| v.as_str()).map(|s| s.to_string()).unwrap_or_else(|| "generated/artifact-1.txt".to_string());
-                    return vec![ArtifactMetadata { path, summary: summary.to_string(), checksum: None, content: None }];
+                    let path = obj
+                        .get("path")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| "generated/artifact-1.txt".to_string());
+                    return vec![ArtifactMetadata {
+                        path,
+                        summary: summary.to_string(),
+                        checksum: None,
+                        content: None,
+                    }];
                 }
             }
         }
     }
-    vec![ArtifactMetadata { path: "generated/artifact-1.txt".to_string(), summary: summarize(text), checksum: None, content: Some(text.to_string()) }]
+    vec![ArtifactMetadata {
+        path: "generated/artifact-1.txt".to_string(),
+        summary: summarize(text),
+        checksum: None,
+        content: Some(text.to_string()),
+    }]
 }
 
 #[async_trait]

--- a/crates/core/src/artifact.rs
+++ b/crates/core/src/artifact.rs
@@ -15,4 +15,3 @@ impl fmt::Display for ArtifactMetadata {
         write!(f, "{} ({})", self.path, self.summary)
     }
 }
-

--- a/crates/core/src/async_backend.rs
+++ b/crates/core/src/async_backend.rs
@@ -1,9 +1,13 @@
-use serde_json::Value;
 use crate::backend::Artifacts;
+use serde_json::Value;
 
 #[async_trait::async_trait]
 pub trait AsyncBackend: Send + Sync {
-    async fn generate(&self, prompt: &str, options: Value) -> Result<Artifacts, crate::backend::BackendError>;
+    async fn generate(
+        &self,
+        prompt: &str,
+        options: Value,
+    ) -> Result<Artifacts, crate::backend::BackendError>;
 }
 
 // A small async mock adapter for the spike. Not wired into the rest of the code yet.
@@ -19,17 +23,25 @@ impl AsyncMockAdapter {
 
 #[async_trait::async_trait]
 impl AsyncBackend for AsyncMockAdapter {
-    async fn generate(&self, _prompt: &str, _options: Value) -> Result<Artifacts, crate::backend::BackendError> {
+    async fn generate(
+        &self,
+        _prompt: &str,
+        _options: Value,
+    ) -> Result<Artifacts, crate::backend::BackendError> {
         // Simulate async delay if present
         if let Some(ms) = self.response.get("timeout_ms").and_then(|v| v.as_u64()) {
             let ms = std::cmp::min(ms, 10_000);
             tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
         }
         if let Some(arr) = self.response.get("artifacts").and_then(|v| v.as_array()) {
-            return Ok(Artifacts { artifacts: arr.clone() });
+            return Ok(Artifacts {
+                artifacts: arr.clone(),
+            });
         }
         // fallback
         let art = serde_json::json!({ "path": "async/mock.txt", "summary": "async mock", "content": "ok" });
-        Ok(Artifacts { artifacts: vec![art] })
+        Ok(Artifacts {
+            artifacts: vec![art],
+        })
     }
 }

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -1,5 +1,5 @@
-use thiserror::Error;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Artifacts {
@@ -15,5 +15,6 @@ pub enum BackendError {
 }
 
 pub trait Backend: Send + Sync {
-    fn generate(&self, prompt: &str, options: serde_json::Value) -> Result<Artifacts, BackendError>;
+    fn generate(&self, prompt: &str, options: serde_json::Value)
+        -> Result<Artifacts, BackendError>;
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -9,7 +9,12 @@ pub struct ProjectConfig {
 }
 
 impl ProjectConfig {
-    pub fn from_str(s: &str) -> Result<Self, toml::de::Error> {
+}
+
+impl std::str::FromStr for ProjectConfig {
+    type Err = toml::de::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         toml::from_str(s)
     }
 }

--- a/crates/core/src/patch.rs
+++ b/crates/core/src/patch.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Hunk {
     /// 1-based inclusive start line
     pub start: usize,
@@ -18,17 +18,6 @@ pub struct Hunk {
     pub expected_original: Option<String>,
 }
 
-impl Default for Hunk {
-    fn default() -> Self {
-        Hunk {
-            start: 0,
-            end: 0,
-            content: String::new(),
-            expected_original: None,
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Patch {
     /// path relative to the working tree root
@@ -40,6 +29,12 @@ pub struct Patch {
 #[derive(Debug)]
 pub struct PatchReport {
     pub conflicts: Vec<String>,
+}
+
+impl Default for PatchReport {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PatchReport {
@@ -158,7 +153,7 @@ pub fn apply_patch_to_working_tree(
         // Prepare replacement lines from hunk.content
         let mut repl: Vec<String> = hunk.content.lines().map(|s| format!("{}\n", s)).collect();
         // If content ends with a newline, lines() will omit the final empty; detect and preserve
-        if hunk.content.ends_with('\n') == false && repl.len() > 0 {
+        if !hunk.content.ends_with('\n') && !repl.is_empty() {
             // the original lines() call dropped newline, so adjust last element
             // but to keep simple, do nothing; we already appended \n above
         }

--- a/crates/core/src/patch.rs
+++ b/crates/core/src/patch.rs
@@ -134,8 +134,10 @@ pub fn apply_patch_to_working_tree(
             // extract current content of the target range
             let mut current = String::new();
             if !lines.is_empty() {
-                for ix in start_idx..=end_idx.min(lines.len().saturating_sub(1)) {
-                    current.push_str(&lines[ix]);
+                // iterate the slice of lines for the target range and accumulate
+                let take_end = end_idx.min(lines.len().saturating_sub(1));
+                for line in lines.iter().take(take_end + 1).skip(start_idx) {
+                    current.push_str(line);
                 }
             }
             // Compare after trimming to be tolerant to trailing newline differences

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -53,8 +53,7 @@ impl Session {
         let mut p = PathBuf::from(dir);
         fs::create_dir_all(&p)?;
         p.push(format!("{}.json", self.id));
-        let data = serde_json::to_vec(self)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let data = serde_json::to_vec(self).map_err(std::io::Error::other)?;
         fs::write(p, data)
     }
 

--- a/crates/core/tests/git_helper.rs
+++ b/crates/core/tests/git_helper.rs
@@ -10,7 +10,11 @@ fn git_helper_creates_branch_and_commit() {
     let dir_path = dir.path();
 
     // Initialize git repo
-    Command::new("git").arg("init").current_dir(&dir_path).assert().success();
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir_path)
+        .assert()
+        .success();
 
     // Create a dummy file and commit using the helper (not implemented yet)
     std::fs::write(dir_path.join("README.md"), "hello").unwrap();

--- a/crates/core/tests/git_helper.rs
+++ b/crates/core/tests/git_helper.rs
@@ -12,7 +12,7 @@ fn git_helper_creates_branch_and_commit() {
     // Initialize git repo
     Command::new("git")
         .arg("init")
-        .current_dir(&dir_path)
+        .current_dir(dir_path)
         .assert()
         .success();
 

--- a/crates/core/tests/integration_adapter_server.rs
+++ b/crates/core/tests/integration_adapter_server.rs
@@ -14,5 +14,6 @@
 fn placeholder_integration_adapter_server_removed() {
     // placeholder to keep test discovery stable; real integration tests live
     // elsewhere if added.
-    assert!(true);
+    // Intentionally empty; presence of this test keeps the file as a valid
+    // test module without performing any runtime work.
 }

--- a/crates/core/tests/parse_artifacts_tests.rs
+++ b/crates/core/tests/parse_artifacts_tests.rs
@@ -27,5 +27,9 @@ fn parses_plain_text_to_single_artifact() {
     let res = parse_artifacts_from_text(txt);
     assert_eq!(res.len(), 1);
     assert_eq!(res[0].path, "generated/artifact-1.txt");
-    assert!(res[0].content.as_deref().unwrap().starts_with("This is a plain text artifact"));
+    assert!(res[0]
+        .content
+        .as_deref()
+        .unwrap()
+        .starts_with("This is a plain text artifact"));
 }

--- a/crates/core/tests/patch_model.rs
+++ b/crates/core/tests/patch_model.rs
@@ -13,7 +13,7 @@ fn patch_model_roundtrip_should_exist() {
     let s = sample.to_string();
 
     // Attempt to deserialize into the expected type (not implemented yet).
-        let _parsed: Result<cprcodr_core::patch::Patch, _> = serde_json::from_str(&s);
+    let _parsed: Result<cprcodr_core::patch::Patch, _> = serde_json::from_str(&s);
     assert!(
         _parsed.is_ok(),
         "Patch model (de)serialisation must be implemented"

--- a/crates/core/tests/test_artifact_metadata.rs
+++ b/crates/core/tests/test_artifact_metadata.rs
@@ -10,7 +10,7 @@ fn artifact_metadata_roundtrip_should_exist() {
     });
 
     let s = sample.to_string();
-        let _parsed: Result<cprcodr_core::artifact::ArtifactMetadata, _> = serde_json::from_str(&s);
+    let _parsed: Result<cprcodr_core::artifact::ArtifactMetadata, _> = serde_json::from_str(&s);
     assert!(
         _parsed.is_ok(),
         "ArtifactMetadata (de)serialization must be implemented"

--- a/crates/core/tests/test_config.rs
+++ b/crates/core/tests/test_config.rs
@@ -8,7 +8,7 @@ default_backend = "ollama"
 default_model = "gpt-4o-mini"
 "#;
 
-    let cfg = ProjectConfig::from_str(sample).expect("parse should succeed");
+    let cfg = sample.parse::<ProjectConfig>().expect("parse should succeed");
     assert_eq!(cfg.id.unwrap(), "testproject");
     assert_eq!(cfg.default_backend.unwrap(), "ollama");
     assert_eq!(cfg.default_model.unwrap(), "gpt-4o-mini");

--- a/crates/core/tests/test_session_serialization.rs
+++ b/crates/core/tests/test_session_serialization.rs
@@ -16,5 +16,8 @@ fn session_roundtrip_serialization_should_exist() {
 
     let s = sample.to_string();
     let _parsed: Result<cprcodr_core::session::Session, _> = serde_json::from_str(&s);
-    assert!(_parsed.is_ok(), "Session (de)serialization must be implemented");
+    assert!(
+        _parsed.is_ok(),
+        "Session (de)serialization must be implemented"
+    );
 }


### PR DESCRIPTION
This PR adds an optional content field to ArtifactMetadata and updates the adapter parsing, adapters, CLI mapping, and tests to preserve full artifact content when available from LLM adapters.\n\n- Add  to \n- Update  to populate \n- Adapt adapters (mock/ollama/lmstudio) and CLI to use  where present\n- Add parser unit tests\n\nAll tests pass locally.