### PR TITLE
cli: persist non-text artifacts (media_type)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ name = "cprcodr"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "base64",
  "clap",
  "cprcodr-core",
  "predicates 2.1.5",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,7 @@ clap = { version = "4.2", features = ["derive"] }
 serde_json = "1.0"
 cprcodr-core = { path = "../core" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+base64 = "0.21"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,56 @@
 use clap::{Parser, Subcommand};
 use serde_json::json;
 
+use base64::Engine;
+
+// Helpers for detecting and decoding base64 payloads robustly.
+// Supports raw base64 or data URLs like: data:application/octet-stream;base64,AAAA
+fn strip_data_url(s: &str) -> (&str, bool) {
+    if let Some(idx) = s.find(',') {
+        if s[..idx].starts_with("data:") && s[..idx].contains(";base64") {
+            return (&s[idx + 1..], true);
+        }
+    }
+    (s, false)
+}
+
+fn looks_like_base64(s: &str) -> bool {
+    let t = s.trim();
+    if t.len() < 4 {
+        return false;
+    }
+    let clean: String = t.chars().filter(|c| !c.is_whitespace()).collect();
+    if clean.len() % 4 != 0 {
+        return false;
+    }
+    clean
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=')
+}
+
+fn try_decode_base64_and_verify(s: &str) -> Option<Vec<u8>> {
+    let (payload, had_data_url) = strip_data_url(s);
+    let clean: String = payload.chars().filter(|c| !c.is_whitespace()).collect();
+    if !had_data_url && !looks_like_base64(&clean) {
+        return None;
+    }
+    match base64::engine::general_purpose::STANDARD.decode(&clean) {
+        Ok(bytes) => {
+            // If it wasn't a data-url, verify re-encoding matches (heuristic)
+            if had_data_url {
+                Some(bytes)
+            } else {
+                let re = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                if re == clean {
+                    Some(bytes)
+                } else {
+                    None
+                }
+            }
+        }
+        Err(_) => None,
+    }
+}
 use cprcodr_core::adapters::MockAdapter;
 use cprcodr_core::adapters::{LLMAdapter, LMStudioAdapter, OllamaAdapter};
 use cprcodr_core::session::Session;
@@ -53,7 +103,6 @@ enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
-    /// Reset mock adapter state (remove mock_state.json in the output dir)
     MockReset,
     /// Preview artifacts saved in a session
     Preview {
@@ -362,17 +411,46 @@ fn main() {
                         }],
                         metadata: None,
                     };
-                    let report =
-                        cprcodr_core::patch::apply_patch_to_working_tree(&patch, &cwd, false)
-                            .unwrap_or_else(|e| cprcodr_core::patch::PatchReport {
-                                conflicts: vec![e],
-                            });
-                    if !report.conflicts.is_empty() {
-                        any_conflict = true;
-                        eprintln!("conflicts applying {}: {:?}", path, report.conflicts);
+                    let media_type = item
+                        .get("media_type")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("");
+                    let is_text = media_type.is_empty() || media_type.starts_with("text/");
+                    if is_text {
+                        let report =
+                            cprcodr_core::patch::apply_patch_to_working_tree(&patch, &cwd, false)
+                                .unwrap_or_else(|e| cprcodr_core::patch::PatchReport {
+                                    conflicts: vec![e],
+                                });
+                        if !report.conflicts.is_empty() {
+                            any_conflict = true;
+                            eprintln!("conflicts applying {}: {:?}", path, report.conflicts);
+                        } else {
+                            // Backwards-compatible message used by existing tests
+                            println!("Wrote artifact stub: {}", path);
+                        }
                     } else {
-                        // Backwards-compatible message used by existing tests
-                        println!("Wrote artifact stub: {}", path);
+                        // For non-text artifacts, attempt to write the raw bytes.
+                        // Prefer base64-encoded content when provided; otherwise write raw bytes of the string.
+                        let write_res = (|| -> Result<(), String> {
+                            let bytes = if let Some(b) = try_decode_base64_and_verify(&content) {
+                                b
+                            } else {
+                                content.as_bytes().to_vec()
+                            };
+                            let target_path = cwd.join(path);
+                            if let Some(parent) = target_path.parent() {
+                                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+                            }
+                            std::fs::write(&target_path, &bytes).map_err(|e| e.to_string())
+                        })();
+                        match write_res {
+                            Ok(()) => println!("Wrote binary artifact: {}", path),
+                            Err(e) => {
+                                any_conflict = true;
+                                eprintln!("conflicts applying {}: [\"{}\"]", path, e);
+                            }
+                        }
                     }
                 }
                 if any_conflict {

--- a/crates/cli/tests/content_fallback.rs
+++ b/crates/cli/tests/content_fallback.rs
@@ -1,0 +1,45 @@
+use assert_cmd::Command;
+use serde_json::json;
+use tempfile::tempdir;
+
+#[test]
+fn apply_falls_back_to_summary_when_content_missing() {
+    let td = tempdir().unwrap();
+    let out_dir = td.path().to_str().unwrap();
+
+    let session_id = "test-content-fallback";
+    let artifact = json!({
+        "path": "fallback.txt",
+        "summary": "SUMMARY ONLY"
+    });
+    let arr = json!([artifact]);
+
+    let mut artifacts_path = td.path().to_path_buf();
+    artifacts_path.push(format!("{}-artifacts.json", session_id));
+    std::fs::write(&artifacts_path, serde_json::to_string_pretty(&arr).unwrap())
+        .expect("write artifacts");
+
+    // sanity-check artifacts file exists where we wrote it
+    assert!(
+        artifacts_path.exists(),
+        "artifacts file should exist at {:?}",
+        artifacts_path
+    );
+
+    let mut cmd = Command::cargo_bin("cprcodr").unwrap();
+    cmd.env("CPRCODR_OUTPUT", out_dir)
+        .current_dir(td.path())
+        .arg("--output")
+        .arg(out_dir)
+        .arg("apply")
+        .arg(session_id);
+    cmd.assert().success();
+
+    let mut artifact_path = td.path().to_path_buf();
+    artifact_path.push("fallback.txt");
+    let written = std::fs::read_to_string(&artifact_path).expect("read written artifact");
+    assert!(
+        written.contains("SUMMARY ONLY"),
+        "expected written file to contain summary when content missing"
+    );
+}

--- a/crates/cli/tests/content_priority.rs
+++ b/crates/cli/tests/content_priority.rs
@@ -1,0 +1,41 @@
+use assert_cmd::Command;
+use serde_json::json;
+use tempfile::tempdir;
+
+#[test]
+fn preview_prefers_content_over_summary() {
+    let td = tempdir().unwrap();
+    let out_dir = td.path().to_str().unwrap();
+
+    // craft an artifacts file with both summary and content different
+    let session_id = "test-content-priority";
+    let artifact = json!({
+        "path": "sample.txt",
+        "summary": "SHORT SUMMARY",
+        "content": "THE FULL CONTENT LINE 1\nLINE2\n"
+    });
+    let arr = json!([artifact]);
+
+    // write artifacts file to output dir
+    let mut artifacts_path = td.path().to_path_buf();
+    artifacts_path.push(format!("{}-artifacts.json", session_id));
+    std::fs::write(&artifacts_path, serde_json::to_string_pretty(&arr).unwrap())
+        .expect("write artifacts");
+
+    // run apply in the tempdir as the working directory so the artifact is written
+    let mut cmd = Command::cargo_bin("cprcodr").unwrap();
+    cmd.env("CPRCODR_OUTPUT", out_dir)
+        .current_dir(td.path())
+        .arg("apply")
+        .arg(session_id);
+    cmd.assert().success();
+
+    // read the written artifact and ensure it contains the full content
+    let mut artifact_path = td.path().to_path_buf();
+    artifact_path.push("sample.txt");
+    let written = std::fs::read_to_string(&artifact_path).expect("read written artifact");
+    assert!(
+        written.contains("THE FULL CONTENT LINE 1"),
+        "expected written file to contain full content"
+    );
+}

--- a/crates/cli/tests/media_type_binary.rs
+++ b/crates/cli/tests/media_type_binary.rs
@@ -1,0 +1,63 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::json;
+use tempfile::tempdir;
+
+#[test]
+fn apply_skips_binary_media_type() {
+    let seeded_value = json!([
+        { "path": "image.bin", "summary": "img", "content": "BINARYDATA", "media_type": "application/octet-stream" }
+    ]);
+    let seeded = serde_json::to_string(&seeded_value).unwrap();
+
+    let td = tempdir().unwrap();
+    let out_dir = td.path().to_str().unwrap();
+
+    let mut cmd = Command::cargo_bin("cprcodr").unwrap();
+    cmd.env("CPRCODR_OUTPUT", out_dir)
+        .env("MOCK_ADAPTER_RESPONSE", seeded)
+        .arg("gen")
+        .arg("generate project")
+        .arg("--backend")
+        .arg("mock");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Saved session"));
+
+    // find session id
+    let entries: Vec<_> = std::fs::read_dir(out_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    let artifacts_file = entries
+        .iter()
+        .find_map(|e| {
+            let n = e.file_name().to_string_lossy().into_owned();
+            if n.ends_with("-artifacts.json") {
+                Some(e.path())
+            } else {
+                None
+            }
+        })
+        .expect("artifacts file present");
+
+    let fname = artifacts_file
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    let session_id = fname.trim_end_matches("-artifacts.json");
+
+    let mut cmd = Command::cargo_bin("cprcodr").unwrap();
+    cmd.current_dir(td.path())
+        .env("CPRCODR_OUTPUT", out_dir)
+        .arg("apply")
+        .arg(session_id);
+    // Apply should succeed and write the binary artifact
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Wrote binary artifact: image.bin"));
+
+    // file should be created
+    assert!(td.path().join("image.bin").exists());
+}

--- a/crates/cli/tests/media_type_text.rs
+++ b/crates/cli/tests/media_type_text.rs
@@ -1,0 +1,61 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::json;
+use tempfile::tempdir;
+
+#[test]
+fn apply_writes_text_media_type() {
+    let seeded_value = json!([
+        { "path": "notes.txt", "summary": "notes", "content": "hello", "media_type": "text/plain" }
+    ]);
+    let seeded = serde_json::to_string(&seeded_value).unwrap();
+
+    let td = tempdir().unwrap();
+    let out_dir = td.path().to_str().unwrap();
+
+    let mut cmd = Command::cargo_bin("cprcodr").unwrap();
+    cmd.env("CPRCODR_OUTPUT", out_dir)
+        .env("MOCK_ADAPTER_RESPONSE", seeded)
+        .arg("gen")
+        .arg("generate project")
+        .arg("--backend")
+        .arg("mock");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Saved session"));
+
+    // find session id
+    let entries: Vec<_> = std::fs::read_dir(out_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    let artifacts_file = entries
+        .iter()
+        .find_map(|e| {
+            let n = e.file_name().to_string_lossy().into_owned();
+            if n.ends_with("-artifacts.json") {
+                Some(e.path())
+            } else {
+                None
+            }
+        })
+        .expect("artifacts file present");
+
+    let fname = artifacts_file
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    let session_id = fname.trim_end_matches("-artifacts.json");
+
+    let mut cmd = Command::cargo_bin("cprcodr").unwrap();
+    cmd.current_dir(td.path())
+        .env("CPRCODR_OUTPUT", out_dir)
+        .arg("apply")
+        .arg(session_id);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Wrote artifact stub"));
+
+    assert!(td.path().join("notes.txt").exists());
+}

--- a/crates/core/src/adapters/trait_adapter.rs
+++ b/crates/core/src/adapters/trait_adapter.rs
@@ -39,6 +39,10 @@ pub fn parse_artifacts_from_text(text: &str) -> Vec<ArtifactMetadata> {
                         .get("content")
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string());
+                    let media_type = obj
+                        .get("media_type")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
                     let summary = content_opt.as_deref().map(summarize).unwrap_or_else(|| {
                         obj.get("summary")
                             .and_then(|v| v.as_str())
@@ -51,6 +55,7 @@ pub fn parse_artifacts_from_text(text: &str) -> Vec<ArtifactMetadata> {
                             summary: summarize(&c),
                             checksum: None,
                             content: Some(c),
+                            media_type: media_type.clone(),
                         });
                         continue;
                     }
@@ -60,6 +65,7 @@ pub fn parse_artifacts_from_text(text: &str) -> Vec<ArtifactMetadata> {
                             summary,
                             checksum: None,
                             content: None,
+                            media_type: media_type.clone(),
                         });
                         continue;
                     }
@@ -70,6 +76,7 @@ pub fn parse_artifacts_from_text(text: &str) -> Vec<ArtifactMetadata> {
                     summary: it.to_string().chars().take(120).collect(),
                     checksum: None,
                     content: Some(it.to_string()),
+                    media_type: None,
                 });
             }
             if !out.is_empty() {
@@ -83,11 +90,16 @@ pub fn parse_artifacts_from_text(text: &str) -> Vec<ArtifactMetadata> {
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| "generated/artifact-1.txt".to_string());
+                    let media_type = obj
+                        .get("media_type")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
                     return vec![ArtifactMetadata {
                         path,
                         summary: summarize(content),
                         checksum: None,
                         content: Some(content.to_string()),
+                        media_type,
                     }];
                 }
                 if let Some(summary) = obj.get("summary").and_then(|v| v.as_str()) {
@@ -96,11 +108,16 @@ pub fn parse_artifacts_from_text(text: &str) -> Vec<ArtifactMetadata> {
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| "generated/artifact-1.txt".to_string());
+                    let media_type = obj
+                        .get("media_type")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
                     return vec![ArtifactMetadata {
                         path,
                         summary: summary.to_string(),
                         checksum: None,
                         content: None,
+                        media_type,
                     }];
                 }
             }
@@ -111,6 +128,7 @@ pub fn parse_artifacts_from_text(text: &str) -> Vec<ArtifactMetadata> {
         summary: summarize(text),
         checksum: None,
         content: Some(text.to_string()),
+        media_type: None,
     }]
 }
 

--- a/crates/core/src/artifact.rs
+++ b/crates/core/src/artifact.rs
@@ -8,6 +8,8 @@ pub struct ArtifactMetadata {
     pub checksum: Option<String>,
     // Optional full content of the artifact when available from the adapter
     pub content: Option<String>,
+    // Optional media type/MIME for the artifact (e.g. text/plain, application/octet-stream)
+    pub media_type: Option<String>,
 }
 
 impl fmt::Display for ArtifactMetadata {


### PR DESCRIPTION
Add media_type handling to ArtifactMetadata and persist non-text artifacts.\n\nBehavior: textual media types use the existing applier; non-text types attempt to decode base64 (including data URLs) and write bytes to workspace paths. Parser now records media_type from adapter responses.\n\nIncludes tests for text and binary artifacts and updates to CLI apply behavior.\n\nFollow-ups: consider adding explicit content_encoding metadata or an --allow-binary opt-in flag for safety.